### PR TITLE
store failed jobs runs URLs on Firebase

### DIFF
--- a/.github/workflows/pr-check-new-entries.yml
+++ b/.github/workflows/pr-check-new-entries.yml
@@ -37,7 +37,6 @@ jobs:
           echo "libraries=$(jq -c 'keys' changed.json)" >> $GITHUB_OUTPUT
           # Keep the full data of changed entries
           echo "library-data=$(jq -c '.' changed.json)"  >> $GITHUB_OUTPUT
-          echo "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ github.job }}"
 
   test-library-on-nightly:
     name: "[${{ matrix.platform }}] ${{ matrix.library }}"

--- a/.github/workflows/test-libraries-on-nightlies.yml
+++ b/.github/workflows/test-libraries-on-nightlies.yml
@@ -63,8 +63,7 @@ jobs:
         if: always()
         run: |
           LIB_FOLDER=$(echo "${{matrix.library}}"  | tr ' ' '_' | tr '/' '_')
-          echo "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ github.job }}"
-          echo "${{matrix.library}}: ${{steps.run-test.outcome}}: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ github.job }}" > "/tmp/$LIB_FOLDER-${{ matrix.platform }}-outcome"
+          echo "${{matrix.library}}: ${{steps.run-test.outcome}}: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" > "/tmp/$LIB_FOLDER-${{ matrix.platform }}-outcome"
           echo "lib_folder=$LIB_FOLDER" >> $GITHUB_OUTPUT
       - name: Upload Artifact
         if: always()

--- a/libraries.json
+++ b/libraries.json
@@ -237,13 +237,5 @@
     "ios": true,
     "maintainersUsernames": [],
     "notes": "One of top most used libraries according to the npm stats"
-  },
-  "react-native-vision-camera": {
-    "description": "A powerful, high-performance React Native Camera library",
-    "installCommand": "react-native-vision-camera",
-    "android": true,
-    "ios": true,
-    "maintainersUsernames": [],
-    "notes": "One of top most used libraries according to the npm stats"
   }
 }


### PR DESCRIPTION
# Why

Store failed runs/jobs URL on Firebase to enable direct linking on the website.

# How

Construct the URL to the job run in the workflows step, attach it to the Firebase outcome data for failures.