### PR TITLE
libraries: use nightly release of `react-native-screens`

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -113,7 +113,7 @@
   },
   "react-native-screens": {
     "description": "Native navigation primitives for your React Native app",
-    "installCommand": "react-native-screens",
+    "installCommand": "react-native-screens@nightly",
     "android": true,
     "ios": true,
     "maintainersUsernames": [],


### PR DESCRIPTION
# Why

`react-native-screens` is published as nightly.

# How

Changed `react-native-screens` to `react-native-screens@nightly` in the libraries list.
