### PR TITLE
website: fetch run URL, add link to failures

### DIFF
--- a/website/components/Table.tsx
+++ b/website/components/Table.tsx
@@ -16,6 +16,8 @@ import data from "~/public/data.json";
 import { type LibraryType } from "~/types/data-types";
 import getCleanPackageName from "~/utils/getCleanPackageName";
 
+import Tooltip from "./Tooltip";
+
 const columnHelper = createColumnHelper<LibraryType>();
 
 function formatStatus(info: CellContext<LibraryType, any>) {
@@ -23,6 +25,17 @@ function formatStatus(info: CellContext<LibraryType, any>) {
     case "success":
       return <span className="select-none">🟢</span>;
     case "failure":
+      const runUrl =
+        info.row.original.results[info.cell.id.split(".")[1]]?.runUrl;
+      if (runUrl) {
+        return (
+          <Tooltip content="See the GitHub action run" delayDuration={0}>
+            <a href={runUrl} target="_blank">
+              <span className="select-none">🔴</span>
+            </a>
+          </Tooltip>
+        );
+      }
       return <span className="select-none">🔴</span>;
     default:
       return <span className="text-secondary select-none">-</span>;

--- a/website/components/Table.tsx
+++ b/website/components/Table.tsx
@@ -35,8 +35,9 @@ function formatStatus(info: CellContext<LibraryType, any>) {
             </a>
           </Tooltip>
         );
+      } else {
+        return <span className="select-none">🔴</span>;
       }
-      return <span className="select-none">🔴</span>;
     default:
       return <span className="text-secondary select-none">-</span>;
   }

--- a/website/components/Tooltip.tsx
+++ b/website/components/Tooltip.tsx
@@ -1,0 +1,33 @@
+import {
+  Provider,
+  Root,
+  Trigger,
+  Portal,
+  Content,
+  Arrow,
+  type TooltipProps,
+} from "@radix-ui/react-tooltip";
+import { type ReactNode } from "react";
+
+type Props = TooltipProps & {
+  content?: ReactNode;
+};
+
+export default function Tooltip({ children, content, delayDuration }: Props) {
+  return (
+    <Provider>
+      <Root delayDuration={delayDuration}>
+        <Trigger asChild>{children}</Trigger>
+        <Portal>
+          <Content
+            className="bg-black px-2.5 py-1 rounded-md text-xs text-white"
+            sideOffset={0}
+          >
+            {content}
+            <Arrow />
+          </Content>
+        </Portal>
+      </Root>
+    </Provider>
+  );
+}

--- a/website/package.json
+++ b/website/package.json
@@ -13,6 +13,7 @@
     "data:fetch": "node ./scripts/fetch-data.mjs"
   },
   "dependencies": {
+    "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-table": "^8.21.3",
     "next": "^15.5.2",
     "next-themes": "^0.4.6",

--- a/website/public/data.json
+++ b/website/public/data.json
@@ -6,10 +6,6 @@
       "@dr.pogodin/react-native-fs": "https://github.com/birdofpreyru/react-native-fs"
     },
     "results": {
-      "2025-08-25": {
-        "android": "success",
-        "ios": "success"
-      },
       "2025-08-26": {
         "android": "success",
         "ios": "success"
@@ -31,6 +27,27 @@
         "ios": "success"
       },
       "2025-09-01": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2025-09-02": {
+        "android": "success",
+        "ios": "success"
+      }
+    }
+  },
+  {
+    "library": "@react-native-async-storage/async-storage",
+    "installCommand": "@react-native-async-storage/async-storage",
+    "repositoryURLs": {
+      "@react-native-async-storage/async-storage": "https://github.com/react-native-async-storage/async-storage/tree/main/packages/default-storage"
+    },
+    "results": {
+      "2025-09-01": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2025-09-02": {
         "android": "success",
         "ios": "success"
       }
@@ -43,10 +60,6 @@
       "@react-native-clipboard/clipboard": "https://github.com/react-native-clipboard/clipboard"
     },
     "results": {
-      "2025-08-25": {
-        "android": "success",
-        "ios": "success"
-      },
       "2025-08-26": {
         "android": "success",
         "ios": "success"
@@ -68,6 +81,10 @@
         "ios": "success"
       },
       "2025-09-01": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2025-09-02": {
         "android": "success",
         "ios": "success"
       }
@@ -80,10 +97,6 @@
       "@react-native-community/datetimepicker": "https://github.com/react-native-datetimepicker/datetimepicker"
     },
     "results": {
-      "2025-08-25": {
-        "android": "success",
-        "ios": "success"
-      },
       "2025-08-26": {
         "android": "success",
         "ios": "success"
@@ -105,6 +118,10 @@
         "ios": "success"
       },
       "2025-09-01": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2025-09-02": {
         "android": "success",
         "ios": "success"
       }
@@ -117,10 +134,6 @@
       "@react-native-community/image-editor": "https://github.com/callstack/react-native-image-editor"
     },
     "results": {
-      "2025-08-25": {
-        "android": "success",
-        "ios": "success"
-      },
       "2025-08-26": {
         "android": "success",
         "ios": "success"
@@ -142,6 +155,10 @@
         "ios": "success"
       },
       "2025-09-01": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2025-09-02": {
         "android": "success",
         "ios": "success"
       }
@@ -154,10 +171,6 @@
       "@react-native-community/netinfo": "https://github.com/react-native-netinfo/react-native-netinfo"
     },
     "results": {
-      "2025-08-25": {
-        "android": "success",
-        "ios": "success"
-      },
       "2025-08-26": {
         "android": "success",
         "ios": "success"
@@ -179,6 +192,10 @@
         "ios": "success"
       },
       "2025-09-01": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2025-09-02": {
         "android": "success",
         "ios": "success"
       }
@@ -191,10 +208,6 @@
       "@react-native-community/slider": "https://github.com/callstack/react-native-slider/tree/main/package"
     },
     "results": {
-      "2025-08-25": {
-        "android": "success",
-        "ios": "success"
-      },
       "2025-08-26": {
         "android": "success",
         "ios": "success"
@@ -216,6 +229,10 @@
         "ios": "success"
       },
       "2025-09-01": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2025-09-02": {
         "android": "success",
         "ios": "success"
       }
@@ -228,10 +245,6 @@
       "@react-native-masked-view/masked-view": "https://github.com/react-native-masked-view/masked-view"
     },
     "results": {
-      "2025-08-25": {
-        "android": "success",
-        "ios": "success"
-      },
       "2025-08-26": {
         "android": "success",
         "ios": "success"
@@ -253,6 +266,53 @@
         "ios": "success"
       },
       "2025-09-01": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2025-09-02": {
+        "android": "success",
+        "ios": "success"
+      }
+    }
+  },
+  {
+    "library": "@sentry/react-native",
+    "installCommand": "@sentry/react-native",
+    "repositoryURLs": {
+      "@sentry/react-native": "https://github.com/getsentry/sentry-react-native/tree/main/packages/core"
+    },
+    "results": {
+      "2025-09-01": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2025-09-02": {
+        "android": "success",
+        "ios": "success"
+      }
+    }
+  },
+  {
+    "library": "@shopify/react-native-skia",
+    "installCommand": "@shopify/react-native-skia",
+    "repositoryURLs": {
+      "@shopify/react-native-skia": "https://github.com/Shopify/react-native-skia/tree/main/packages/skia"
+    },
+    "results": {
+      "2025-09-02": {
+        "android": "success",
+        "ios": "success"
+      }
+    }
+  },
+  {
+    "library": "lottie-react-native/lottie-react-native",
+    "installCommand": "lottie-react-native",
+    "repositoryURLs": {
+      "lottie-react-native": "https://github.com/lottie-react-native/lottie-react-native/tree/master/packages/core"
+    },
+    "results": {
+      "2025-09-02": {
         "android": "success",
         "ios": "success"
       }
@@ -262,10 +322,6 @@
     "library": "react-native-async-storage",
     "installCommand": "react-native-async-storage",
     "results": {
-      "2025-08-25": {
-        "android": "success",
-        "ios": "success"
-      },
       "2025-08-26": {
         "android": "success",
         "ios": "success"
@@ -287,6 +343,10 @@
         "ios": "success"
       },
       "2025-09-01": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2025-09-02": {
         "android": "success",
         "ios": "success"
       }
@@ -299,10 +359,6 @@
       "react-native-blob-util": "https://github.com/RonRadtke/react-native-blob-util"
     },
     "results": {
-      "2025-08-25": {
-        "android": "success",
-        "ios": "success"
-      },
       "2025-08-26": {
         "android": "success",
         "ios": "success"
@@ -324,6 +380,10 @@
         "ios": "success"
       },
       "2025-09-01": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2025-09-02": {
         "android": "success",
         "ios": "success"
       }
@@ -336,10 +396,6 @@
       "react-native-contacts": "https://github.com/rt2zz/react-native-contacts"
     },
     "results": {
-      "2025-08-25": {
-        "android": "failure",
-        "ios": "success"
-      },
       "2025-08-26": {
         "android": "failure",
         "ios": "success"
@@ -362,6 +418,11 @@
       },
       "2025-09-01": {
         "android": "failure",
+        "ios": "success"
+      },
+      "2025-09-02": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/17411668912",
         "ios": "success"
       }
     }
@@ -373,10 +434,6 @@
       "react-native-device-info": "https://github.com/react-native-device-info/react-native-device-info"
     },
     "results": {
-      "2025-08-25": {
-        "android": "success",
-        "ios": "success"
-      },
       "2025-08-26": {
         "android": "success",
         "ios": "success"
@@ -398,6 +455,27 @@
         "ios": "success"
       },
       "2025-09-01": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2025-09-02": {
+        "android": "success",
+        "ios": "success"
+      }
+    }
+  },
+  {
+    "library": "react-native-edge-to-edge",
+    "installCommand": "react-native-edge-to-edge",
+    "repositoryURLs": {
+      "react-native-edge-to-edge": "https://github.com/zoontek/react-native-edge-to-edge"
+    },
+    "results": {
+      "2025-09-01": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2025-09-02": {
         "android": "success",
         "ios": "success"
       }
@@ -410,10 +488,6 @@
       "react-native-email-link": "https://github.com/flexible-agency/react-native-email-link"
     },
     "results": {
-      "2025-08-25": {
-        "android": "success",
-        "ios": "success"
-      },
       "2025-08-26": {
         "android": "success",
         "ios": "success"
@@ -435,6 +509,10 @@
         "ios": "success"
       },
       "2025-09-01": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2025-09-02": {
         "android": "success",
         "ios": "success"
       }
@@ -447,10 +525,6 @@
       "react-native-gesture-handler": "https://github.com/software-mansion/react-native-gesture-handler/tree/main/packages/react-native-gesture-handler"
     },
     "results": {
-      "2025-08-25": {
-        "android": "success",
-        "ios": "success"
-      },
       "2025-08-26": {
         "android": "success",
         "ios": "success"
@@ -472,6 +546,10 @@
         "ios": "success"
       },
       "2025-09-01": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2025-09-02": {
         "android": "success",
         "ios": "success"
       }
@@ -484,10 +562,6 @@
       "react-native-image-picker": "https://github.com/react-native-image-picker/react-native-image-picker"
     },
     "results": {
-      "2025-08-25": {
-        "android": "success",
-        "ios": "success"
-      },
       "2025-08-26": {
         "android": "success",
         "ios": "success"
@@ -509,6 +583,23 @@
         "ios": "success"
       },
       "2025-09-01": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2025-09-02": {
+        "android": "success",
+        "ios": "success"
+      }
+    }
+  },
+  {
+    "library": "react-native-keyboard-controller",
+    "installCommand": "react-native-keyboard-controller",
+    "repositoryURLs": {
+      "react-native-keyboard-controller": "https://github.com/kirillzyusko/react-native-keyboard-controller"
+    },
+    "results": {
+      "2025-09-02": {
         "android": "success",
         "ios": "success"
       }
@@ -521,10 +612,6 @@
       "react-native-linear-gradient": "https://github.com/react-native-linear-gradient/react-native-linear-gradient"
     },
     "results": {
-      "2025-08-25": {
-        "android": "success",
-        "ios": "success"
-      },
       "2025-08-26": {
         "android": "success",
         "ios": "success"
@@ -546,6 +633,10 @@
         "ios": "success"
       },
       "2025-09-01": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2025-09-02": {
         "android": "success",
         "ios": "success"
       }
@@ -555,10 +646,6 @@
     "library": "react-native-masked-view",
     "installCommand": "react-native-masked-view",
     "results": {
-      "2025-08-25": {
-        "android": "success",
-        "ios": "success"
-      },
       "2025-08-26": {
         "android": "success",
         "ios": "success"
@@ -580,6 +667,10 @@
         "ios": "success"
       },
       "2025-09-01": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2025-09-02": {
         "android": "success",
         "ios": "success"
       }
@@ -592,10 +683,6 @@
       "react-native-mmkv": "https://github.com/mrousavy/react-native-mmkv/tree/main/package"
     },
     "results": {
-      "2025-08-25": {
-        "android": "failure",
-        "ios": "success"
-      },
       "2025-08-26": {
         "android": "failure",
         "ios": "success"
@@ -618,6 +705,11 @@
       },
       "2025-09-01": {
         "android": "failure",
+        "ios": "success"
+      },
+      "2025-09-02": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/17411668912",
         "ios": "success"
       }
     }
@@ -629,10 +721,6 @@
       "react-native-pager-view": "https://github.com/callstack/react-native-pager-view"
     },
     "results": {
-      "2025-08-25": {
-        "android": "success",
-        "ios": "success"
-      },
       "2025-08-26": {
         "android": "success",
         "ios": "success"
@@ -654,6 +742,10 @@
         "ios": "success"
       },
       "2025-09-01": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2025-09-02": {
         "android": "success",
         "ios": "success"
       }
@@ -666,10 +758,6 @@
       "react-native-permissions": "https://github.com/yonahforst/react-native-permissions"
     },
     "results": {
-      "2025-08-25": {
-        "android": "success",
-        "ios": "success"
-      },
       "2025-08-26": {
         "android": "success",
         "ios": "success"
@@ -691,6 +779,10 @@
         "ios": "success"
       },
       "2025-09-01": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2025-09-02": {
         "android": "success",
         "ios": "success"
       }
@@ -704,10 +796,6 @@
       "react-native-worklets": "https://github.com/software-mansion/react-native-reanimated/tree/main/packages/react-native-worklets"
     },
     "results": {
-      "2025-08-25": {
-        "android": "failure",
-        "ios": "success"
-      },
       "2025-08-26": {
         "android": "failure",
         "ios": "success"
@@ -730,21 +818,22 @@
       },
       "2025-09-01": {
         "android": "failure",
+        "ios": "success"
+      },
+      "2025-09-02": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/17411668912",
         "ios": "success"
       }
     }
   },
   {
     "library": "react-native-screens",
-    "installCommand": "react-native-screens",
+    "installCommand": "react-native-screens@nightly",
     "repositoryURLs": {
       "react-native-screens": "https://github.com/software-mansion/react-native-screens"
     },
     "results": {
-      "2025-08-25": {
-        "android": "success",
-        "ios": "success"
-      },
       "2025-08-26": {
         "android": "success",
         "ios": "success"
@@ -766,6 +855,27 @@
         "ios": "success"
       },
       "2025-09-01": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2025-09-02": {
+        "android": "success",
+        "ios": "success"
+      }
+    }
+  },
+  {
+    "library": "react-native-share",
+    "installCommand": "react-native-share",
+    "repositoryURLs": {
+      "react-native-share": "https://github.com/react-native-share/react-native-share"
+    },
+    "results": {
+      "2025-09-01": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2025-09-02": {
         "android": "success",
         "ios": "success"
       }
@@ -778,10 +888,6 @@
       "react-native-svg": "https://github.com/software-mansion/react-native-svg"
     },
     "results": {
-      "2025-08-25": {
-        "android": "success",
-        "ios": "success"
-      },
       "2025-08-26": {
         "android": "success",
         "ios": "success"
@@ -803,6 +909,10 @@
         "ios": "success"
       },
       "2025-09-01": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2025-09-02": {
         "android": "success",
         "ios": "success"
       }
@@ -812,10 +922,6 @@
     "library": "react-native-vector-icons",
     "installCommand": "react-native-vector-icons",
     "results": {
-      "2025-08-25": {
-        "android": "success",
-        "ios": "success"
-      },
       "2025-08-26": {
         "android": "success",
         "ios": "success"
@@ -837,6 +943,10 @@
         "ios": "success"
       },
       "2025-09-01": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2025-09-02": {
         "android": "success",
         "ios": "success"
       }
@@ -849,10 +959,6 @@
       "react-native-video": "https://github.com/TheWidlarzGroup/react-native-video"
     },
     "results": {
-      "2025-08-25": {
-        "android": "success",
-        "ios": "success"
-      },
       "2025-08-26": {
         "android": "success",
         "ios": "success"
@@ -874,6 +980,10 @@
         "ios": "success"
       },
       "2025-09-01": {
+        "android": "failure",
+        "ios": "success"
+      },
+      "2025-09-02": {
         "android": "success",
         "ios": "success"
       }
@@ -886,10 +996,6 @@
       "react-native-webview": "https://github.com/react-native-webview/react-native-webview"
     },
     "results": {
-      "2025-08-25": {
-        "android": "success",
-        "ios": "success"
-      },
       "2025-08-26": {
         "android": "success",
         "ios": "success"
@@ -912,6 +1018,24 @@
       },
       "2025-09-01": {
         "android": "success",
+        "ios": "success"
+      },
+      "2025-09-02": {
+        "android": "success",
+        "ios": "success"
+      }
+    }
+  },
+  {
+    "library": "react-native-worklets",
+    "installCommand": "react-native-worklets@nightly",
+    "repositoryURLs": {
+      "react-native-worklets": "https://github.com/software-mansion/react-native-reanimated/tree/main/packages/react-native-worklets"
+    },
+    "results": {
+      "2025-09-02": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/17411668912",
         "ios": "success"
       }
     }
@@ -924,10 +1048,6 @@
       "scandit-react-native-datacapture-core": "https://github.com/Scandit/scandit-react-native-datacapture-core"
     },
     "results": {
-      "2025-08-25": {
-        "android": "failure",
-        "ios": "success"
-      },
       "2025-08-26": {
         "android": "failure",
         "ios": "success"
@@ -950,6 +1070,11 @@
       },
       "2025-09-01": {
         "android": "failure",
+        "ios": "success"
+      },
+      "2025-09-02": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/17411668912",
         "ios": "success"
       }
     }

--- a/website/scripts/fetch-data.mjs
+++ b/website/scripts/fetch-data.mjs
@@ -67,7 +67,7 @@ async function main() {
   );
 
   for (const [date, entries] of trimmedData) {
-    for (const { library, platform, status } of entries) {
+    for (const { library, platform, status, runUrl } of entries) {
       if (!tableDataMap.has(library)) {
         const installCommand = definitionsJSON[library].installCommand;
         const directoryData = await fetchDirectoryData(
@@ -96,6 +96,9 @@ async function main() {
         rec.results[date] = {};
       }
       rec.results[date][platform.toLowerCase()] = status;
+      if (status === "failure") {
+        rec.results[date].runUrl = runUrl;
+      }
     }
   }
 

--- a/website/types/data-types.ts
+++ b/website/types/data-types.ts
@@ -7,6 +7,7 @@ export type LibraryType = {
     {
       android?: "success" | "failure";
       ios?: "success" | "failure";
+      runUrl?: string;
     }
   >;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1151,6 +1151,33 @@
   dependencies:
     tslib "^2.1.0"
 
+"@floating-ui/core@^1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.7.3.tgz#462d722f001e23e46d86fd2bd0d21b7693ccb8b7"
+  integrity sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==
+  dependencies:
+    "@floating-ui/utils" "^0.2.10"
+
+"@floating-ui/dom@^1.7.4":
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.7.4.tgz#ee667549998745c9c3e3e84683b909c31d6c9a77"
+  integrity sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==
+  dependencies:
+    "@floating-ui/core" "^1.7.3"
+    "@floating-ui/utils" "^0.2.10"
+
+"@floating-ui/react-dom@^2.0.0":
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.1.6.tgz#189f681043c1400561f62972f461b93f01bf2231"
+  integrity sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==
+  dependencies:
+    "@floating-ui/dom" "^1.7.4"
+
+"@floating-ui/utils@^0.2.10":
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.10.tgz#a2a1e3812d14525f725d011a73eceb41fef5bc1c"
+  integrity sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==
+
 "@google-cloud/firestore@^7.11.0":
   version "7.11.3"
   resolved "https://registry.yarnpkg.com/@google-cloud/firestore/-/firestore-7.11.3.tgz#87cc3a58c5c297d6c9ca0e486fbf16b403585721"
@@ -1752,6 +1779,168 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
+
+"@radix-ui/primitive@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.3.tgz#e2dbc13bdc5e4168f4334f75832d7bdd3e2de5ba"
+  integrity sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==
+
+"@radix-ui/react-arrow@1.1.7":
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz#e14a2657c81d961598c5e72b73dd6098acc04f09"
+  integrity sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==
+  dependencies:
+    "@radix-ui/react-primitive" "2.1.3"
+
+"@radix-ui/react-compose-refs@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz#a2c4c47af6337048ee78ff6dc0d090b390d2bb30"
+  integrity sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==
+
+"@radix-ui/react-context@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.2.tgz#61628ef269a433382c364f6f1e3788a6dc213a36"
+  integrity sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==
+
+"@radix-ui/react-dismissable-layer@1.1.11":
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz#e33ab6f6bdaa00f8f7327c408d9f631376b88b37"
+  integrity sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-use-callback-ref" "1.1.1"
+    "@radix-ui/react-use-escape-keydown" "1.1.1"
+
+"@radix-ui/react-id@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-1.1.1.tgz#1404002e79a03fe062b7e3864aa01e24bd1471f7"
+  integrity sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+
+"@radix-ui/react-popper@1.2.8":
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-popper/-/react-popper-1.2.8.tgz#a79f39cdd2b09ab9fb50bf95250918422c4d9602"
+  integrity sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==
+  dependencies:
+    "@floating-ui/react-dom" "^2.0.0"
+    "@radix-ui/react-arrow" "1.1.7"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-use-callback-ref" "1.1.1"
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+    "@radix-ui/react-use-rect" "1.1.1"
+    "@radix-ui/react-use-size" "1.1.1"
+    "@radix-ui/rect" "1.1.1"
+
+"@radix-ui/react-portal@1.1.9":
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.1.9.tgz#14c3649fe48ec474ac51ed9f2b9f5da4d91c4472"
+  integrity sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==
+  dependencies:
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+
+"@radix-ui/react-presence@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.1.5.tgz#5d8f28ac316c32f078afce2996839250c10693db"
+  integrity sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+
+"@radix-ui/react-primitive@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz#db9b8bcff49e01be510ad79893fb0e4cda50f1bc"
+  integrity sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==
+  dependencies:
+    "@radix-ui/react-slot" "1.2.3"
+
+"@radix-ui/react-slot@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.2.3.tgz#502d6e354fc847d4169c3bc5f189de777f68cfe1"
+  integrity sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.2"
+
+"@radix-ui/react-tooltip@^1.2.8":
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz#3f50267e25bccfc9e20bb3036bfd9ab4c2c30c2c"
+  integrity sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-dismissable-layer" "1.1.11"
+    "@radix-ui/react-id" "1.1.1"
+    "@radix-ui/react-popper" "1.2.8"
+    "@radix-ui/react-portal" "1.1.9"
+    "@radix-ui/react-presence" "1.1.5"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-slot" "1.2.3"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
+    "@radix-ui/react-visually-hidden" "1.2.3"
+
+"@radix-ui/react-use-callback-ref@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz#62a4dba8b3255fdc5cc7787faeac1c6e4cc58d40"
+  integrity sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==
+
+"@radix-ui/react-use-controllable-state@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz#905793405de57d61a439f4afebbb17d0645f3190"
+  integrity sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==
+  dependencies:
+    "@radix-ui/react-use-effect-event" "0.0.2"
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+
+"@radix-ui/react-use-effect-event@0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz#090cf30d00a4c7632a15548512e9152217593907"
+  integrity sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+
+"@radix-ui/react-use-escape-keydown@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz#b3fed9bbea366a118f40427ac40500aa1423cc29"
+  integrity sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==
+  dependencies:
+    "@radix-ui/react-use-callback-ref" "1.1.1"
+
+"@radix-ui/react-use-layout-effect@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz#0c4230a9eed49d4589c967e2d9c0d9d60a23971e"
+  integrity sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==
+
+"@radix-ui/react-use-rect@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz#01443ca8ed071d33023c1113e5173b5ed8769152"
+  integrity sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==
+  dependencies:
+    "@radix-ui/rect" "1.1.1"
+
+"@radix-ui/react-use-size@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz#6de276ffbc389a537ffe4316f5b0f24129405b37"
+  integrity sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+
+"@radix-ui/react-visually-hidden@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz#a8c38c8607735dc9f05c32f87ab0f9c2b109efbf"
+  integrity sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==
+  dependencies:
+    "@radix-ui/react-primitive" "2.1.3"
+
+"@radix-ui/rect@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/rect/-/rect-1.1.1.tgz#78244efe12930c56fd255d7923865857c41ac8cb"
+  integrity sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==
 
 "@rtsao/scc@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
# Why

Make it easier to navigate to the failed runs from the website.

# How

Update fetch data script for the website, add link with a tooltip to the cells with failed check.

# Preview

<img width="1438" height="436" alt="Screenshot 2025-09-02 at 21 02 22" src="https://github.com/user-attachments/assets/5019fc43-f801-4641-bd39-094b7dc6a7e8" />
