### PR TITLE
libraries: add `react-native-iap` and `react-native-audio-recorder-player`

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -278,6 +278,14 @@
     "maintainersUsernames": ["hyochan"],
     "notes": ""
   },
+  "react-native-nitro-modules": {
+    "description": "Insanely fast native C++, Swift or Kotlin modules with a statically compiled binding layer to JSI",
+    "installCommand": "react-native-nitro-modules",
+    "android": true,
+    "ios": true,
+    "maintainersUsernames": [],
+    "notes": "Required dependency for react-native-audio-recorder-player"
+  },
   "react-native-audio-recorder-player": {
     "description": "Cross-platform audio recorder & player with native backends.",
     "installCommand": "react-native-audio-recorder-player",

--- a/libraries.json
+++ b/libraries.json
@@ -269,5 +269,21 @@
     "ios": true,
     "maintainersUsernames": [],
     "notes": "One of top most used libraries according to the npm stats"
+  },
+  "react-native-iap": {
+    "description": "In-app purchases for React Native (StoreKit 2 / Play Billing v8).",
+    "installCommand": "react-native-iap",
+    "android": true,
+    "ios": true,
+    "maintainersUsernames": ["hyochan"],
+    "notes": ""
+  },
+  "react-native-audio-recorder-player": {
+    "description": "Cross-platform audio recorder & player with native backends.",
+    "installCommand": "react-native-audio-recorder-player",
+    "android": true,
+    "ios": true,
+    "maintainersUsernames": ["hyochan"],
+    "notes": ""
   }
 }

--- a/libraries.json
+++ b/libraries.json
@@ -286,14 +286,6 @@
     "maintainersUsernames": ["hyochan"],
     "notes": ""
   },
-  "react-native-nitro-modules": {
-    "description": "Insanely fast native C++, Swift or Kotlin modules with a statically compiled binding layer to JSI",
-    "installCommand": "react-native-nitro-modules",
-    "android": true,
-    "ios": true,
-    "maintainersUsernames": [],
-    "notes": "Required dependency for react-native-audio-recorder-player"
-  },
   "react-native-audio-recorder-player": {
     "description": "Cross-platform audio recorder & player with native backends.",
     "installCommand": "react-native-nitro-modules react-native-audio-recorder-player",

--- a/libraries.json
+++ b/libraries.json
@@ -280,7 +280,7 @@
   },
   "react-native-iap": {
     "description": "In-app purchases for React Native (StoreKit 2 / Play Billing v8).",
-    "installCommand": "react-native-iap",
+    "installCommand": "react-native-nitro-modules react-native-iap",
     "android": true,
     "ios": true,
     "maintainersUsernames": ["hyochan"],
@@ -296,7 +296,7 @@
   },
   "react-native-audio-recorder-player": {
     "description": "Cross-platform audio recorder & player with native backends.",
-    "installCommand": "react-native-audio-recorder-player",
+    "installCommand": "react-native-nitro-modules react-native-audio-recorder-player",
     "android": true,
     "ios": true,
     "maintainersUsernames": ["hyochan"],


### PR DESCRIPTION
## Why
Both libraries are among the top most used React Native libraries according to npm stats and meet all the requirements for the nightly testing program:

* `react-native-iap`: Essential library for in-app purchases, widely used across iOS and Android apps
* `react-native-audio-recorder-player`: Popular audio recording and playback solution for React Native

Refs:
* **Introducing the React Native Nightly testing program 🌑🌓🌔🌕🌖🌗 discussions-and-proposals#931**

## How
Add both `react-native-iap` and `react-native-audio-recorder-player` to the libraries list for comprehensive testing coverage of payment and audio functionality in the React Native ecosystem.