### PR TITLE
libraries: add `react-native-maps`

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -317,5 +317,13 @@
     "ios": true,
     "maintainersUsernames": ["mdjastrzebski"],
     "notes": "One of top most used libraries according to the npm stats"
+  },
+  "react-native-maps": {
+    "description": "React Native Mapview component for Android and iOS",
+    "installCommand": "react-native-maps",
+    "android": true,
+    "ios": true,
+    "maintainersUsernames": [""],
+    "notes": "One of top most used libraries according to the npm stats"
   }
 }


### PR DESCRIPTION
# Why

One of top most used libraries according to the npm stats:
* https://reactnative.directory/?search=https%3A%2F%2Fgithub.com%2Freact-native-maps%2Freact-native-maps

# How

Add `react-native-maps` to the libraries list.