### PR TITLE
libraries: add react-native-nitro-sound

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -294,9 +294,9 @@
     "maintainersUsernames": ["hyochan"],
     "notes": ""
   },
-  "react-native-audio-recorder-player": {
-    "description": "Cross-platform audio recorder & player with native backends.",
-    "installCommand": "react-native-nitro-modules react-native-audio-recorder-player",
+  "react-native-nitro-sound": {
+    "description": "Audio recorder & player with native backends. Provides modern hook APIs, supports multiple instances, and ensures stable performance.",
+    "installCommand": "react-native-nitro-sound react-native-nitro-modules",
     "android": true,
     "ios": true,
     "maintainersUsernames": ["hyochan"],


### PR DESCRIPTION
## Why

The previously added `react-native-audio-recorder-player` has now been rebranded as **`react-native-nitro-sound`**, and this PR updates the reference accordingly.

## How

Replace `react-native-audio-recorder-player` with `react-native-nitro-sound` in the nightly testing libraries list, so testing coverage continues for audio recording and playback in the React Native ecosystem.
