### PR TITLE
libraries: added @react-native-seoul/naver-login

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -325,5 +325,13 @@
     "ios": true,
     "maintainersUsernames": [""],
     "notes": "One of top most used libraries according to the npm stats"
+  },
+  "@react-native-seoul/naver-login": {
+    "description": "One of the biggest SNS Auth Platform in Korea, Naver login for React Native",
+    "installCommand": "@react-native-seoul/naver-login",
+    "android": true,
+    "ios": true,
+    "maintainersUsernames": ["chanwoong528"],
+    "notes": "One of top most used libraries according to the npm stats"
   }
 }


### PR DESCRIPTION
GitHub: https://github.com/crossplatformkorea/react-native-naver-login
Here: https://www.npmjs.com/package/@react-native-seoul/naver-login

Why
this library is a crucial library for Users in Korea in order to do the SNS Auth.

How
Add @react-native-seoul/naver-login to libraries.json