### PR TITLE
Add react-native-bootsplash and react-native-localize

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -325,5 +325,21 @@
     "ios": true,
     "maintainersUsernames": [""],
     "notes": "One of top most used libraries according to the npm stats"
+  },
+  "react-native-bootsplash": {
+    "description": "Show a splash screen during app startup",
+    "installCommand": "react-native-bootsplash",
+    "android": true,
+    "ios": true,
+    "maintainersUsernames": ["zoontek"],
+    "notes": "One of top most used libraries according to the npm stats"
+  },
+  "react-native-localize": {
+    "description": "A toolbox for your React Native app localization",
+    "installCommand": "react-native-localize",
+    "android": true,
+    "ios": true,
+    "maintainersUsernames": ["zoontek"],
+    "notes": "One of top most used libraries according to the npm stats"
   }
 }


### PR DESCRIPTION
Both libraries are among the top most used React Native libraries according to npm stats and meet all the requirements for the nightly testing program:

- `react-native-bootsplash`: Show a splash screen during app startup
- `react-native-localize`: A toolbox for your React Native app localization

Requirements: https://github.com/react-native-community/discussions-and-proposals/discussions/931