### PR TITLE
ci: delay website scheduled deployment

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -2,9 +2,9 @@ name: Deploy website
 
 on:
   workflow_dispatch:
-  # deploy daily @ 4:55 AM UTC
+  # deploy daily @ 5:30 AM UTC
   schedule:
-    - cron: '55 4 * * *'
+    - cron: '30 5 * * *'
   push:
     branches:
       - main


### PR DESCRIPTION
# Why

To make sure that updated data from nightly run is available in Firebase store at the time of deployment.

# How

Update scheduled workflow run to happen at 5:30 AM instead of 4:55 AM.

In the future, we should try to chain the website deployment workflow with nightly run, so manual adjustments are not needed.