### PR TITLE
Fix iOS nightlies

### DIFF
--- a/.github/actions/test-library-on-nightly/action.yml
+++ b/.github/actions/test-library-on-nightly/action.yml
@@ -26,7 +26,7 @@ runs:
       if: ${{ inputs.platform == 'ios' }}
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: latest-stable
+        xcode-version: 16.4.0
     - name: Build iOS
       shell: bash
       if: ${{ inputs.platform == 'ios' }}


### PR DESCRIPTION
As seen on discord nightly are failing on xcode 26

<img width="973" height="292" alt="image" src="https://github.com/user-attachments/assets/c9b12c05-58ad-459f-807e-67c3902c2159" />

Xcode 26 is not stable and still in beta. I am not sure why it is being set for nightlies. Maybe this is a bug with [setup-xcode](https://github.com/maxim-lobanov/setup-xcode).

<img width="631" height="149" alt="image" src="https://github.com/user-attachments/assets/6583299b-fc1d-4c98-9a50-82c5426bf853" />


I am making it to xcode 16.4. 



