### PR TITLE
Add react-native-enriched-markdown to nightly tests

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -425,5 +425,13 @@
     "maintainersUsernames": ["riteshshukla04", "szymon20000"],
     "notes": "",
     "patchFile": ""
+  },
+  "react-native-enriched-markdown": {
+    "description": "Markdown Input & Text for React Native",
+    "installCommand": "react-native-enriched-markdown@nightly",
+    "android": true,
+    "ios": true,
+    "maintainersUsernames": ["hryhoriiK97"],
+    "notes": ""
   }
 }


### PR DESCRIPTION
## Summary
[react-native-enriched-markdown](https://www.npmjs.com/package/react-native-enriched-markdown) provides native Markdown text rendering and a rich text input with Markdown output for React Native. It supports iOS, Android, macOS, and Web, and requires the New Architecture (Fabric) on native platforms.

## Eligibility criteria
Per the [nightly testing program requirements](https://github.com/react-native-community/discussions-and-proposals/discussions/931):

| Criterion | Status |
|---|---|
| Actively maintained (release in the last year) | v0.6.0 released May 26, 2026 |
| More than 100 GitHub stars | 693 stars |
| More than 50,000 monthly NPM downloads | ~271k/month |
| Contains native code | Kotlin, Objective-C, C++, C |

<img width="1175" height="220" alt="Screenshot 2026-06-01 at 12 18 58" src="https://github.com/user-attachments/assets/4644b4f1-2409-4b76-a7f6-c5c3a0e4190b" />