### PR TITLE
add display mode filter, fix firebase data fetch

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,11 +1,11 @@
+import { defineConfig, globalIgnores } from 'eslint/config';
+import globals from 'globals';
+import importPlugin from 'eslint-plugin-import';
+import jestPlugin from 'eslint-plugin-jest';
 import jsPlugin from '@eslint/js';
 import jsonPlugin from '@eslint/json';
 import markdownPlugin from '@eslint/markdown';
-import { defineConfig, globalIgnores } from 'eslint/config';
-import importPlugin from 'eslint-plugin-import';
-import jestPlugin from 'eslint-plugin-jest';
 import prettierPlugin from 'eslint-plugin-prettier/recommended';
-import globals from 'globals';
 
 export default defineConfig([
   globalIgnores(['website']),
@@ -41,18 +41,14 @@ export default defineConfig([
     },
     extends: ['js/recommended'],
     rules: {
-      'import/no-unresolved': 'off',
-      'import/enforce-node-protocol-usage': ['error', 'always'],
-      'import/order': [
+      'sort-imports': [
         'error',
         {
-          groups: [['external', 'builtin'], 'internal', ['parent', 'sibling']],
-          'newlines-between': 'always',
-          alphabetize: {
-            order: 'asc',
-          },
+          allowSeparatedGroups: true,
         },
       ],
+      'import/no-unresolved': 'off',
+      'import/enforce-node-protocol-usage': ['error', 'always'],
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@eslint/js": "^10.0.1",
     "@eslint/json": "^2.0.0",
     "@eslint/markdown": "^8.0.2",
-    "eslint": "^10.4.1",
+    "eslint": "^10.5.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jest": "^29.15.2",
@@ -27,7 +27,7 @@
     "jest": "^30.4.2",
     "prettier": "^3.8.4",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.61.0"
+    "typescript-eslint": "^8.61.1"
   },
   "resolutions": {
     "postcss": "^8.5.15"

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
-import localFont from 'next/font/local';
 import { ThemeProvider } from 'next-themes';
+import localFont from 'next/font/local';
+
 import { PropsWithChildren, Suspense } from 'react';
 
 import Footer from '~/components/Footer';

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -71,7 +71,7 @@ export default function RootLayout({ children }: PropsWithChildren) {
           <Suspense>
             <SearchProvider>
               <Header />
-              <div className="min-h-[calc(100dvh-58px)] grid grid-rows-[1fr_min-content]">
+              <div className="min-h-[calc(100dvh-60px)] grid grid-rows-[1fr_min-content]">
                 {children}
                 <Footer />
               </div>

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -1,9 +1,10 @@
 import Link from 'next/link';
 
+import DisplayModeSelector from '~/components/DisplayModeSelector';
 import Table from '~/components/Table';
+
 import AndroidIcon from '~/public/icons/android-icon.svg';
 import IOSIcon from '~/public/icons/ios-icon.svg';
-import DisplayModeSelector from '~/components/DisplayModeSelector';
 
 export default function Home() {
   return (

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -8,7 +8,7 @@ import DisplayModeSelector from '~/components/DisplayModeSelector';
 export default function Home() {
   return (
     <main className="max-w-[1280px] w-full mx-auto flex flex-col gap-4 pt-6 pb-8 px-4 overflow-auto">
-      <h2 className="flex justify-between items-center">
+      <h2 className="flex justify-between items-center max-lg:flex-col gap-x-2 max-lg:gap-y-3">
         Results of automated GitHub Actions workflows testing React Native
         ecosystem libraries against nightly builds.
         <DisplayModeSelector />

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -3,13 +3,15 @@ import Link from 'next/link';
 import Table from '~/components/Table';
 import AndroidIcon from '~/public/icons/android-icon.svg';
 import IOSIcon from '~/public/icons/ios-icon.svg';
+import DisplayModeSelector from '~/components/DisplayModeSelector';
 
 export default function Home() {
   return (
-    <main className="max-w-[1280px] w-full mx-auto flex flex-col gap-4 py-8 px-4 overflow-auto">
-      <h2 className="mb-2">
+    <main className="max-w-[1280px] w-full mx-auto flex flex-col gap-4 pt-6 pb-8 px-4 overflow-auto">
+      <h2 className="flex justify-between items-center">
         Results of automated GitHub Actions workflows testing React Native
-        ecosystem libraries against nightly builds:
+        ecosystem libraries against nightly builds.
+        <DisplayModeSelector />
       </h2>
       <Link href="#android" className="w-fit inline-flex rounded-lg pr-2">
         <h3

--- a/website/components/DisplayModeSelector.tsx
+++ b/website/components/DisplayModeSelector.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { twMerge } from 'tailwind-merge';
+import { useSearch } from '~/context/SearchContext';
+
+export default function DisplayModeSelector() {
+  const { displayMode, setDisplayMode } = useSearch();
+
+  return (
+    <div className="flex border border-border rounded-lg p-1 gap-1 bg-subtle">
+      <button
+        onClick={() => setDisplayMode('all')}
+        className={twMerge(
+          'text-sm font-normal px-3 py-1 rounded text-secondary cursor-pointer transition-colors',
+          displayMode === 'all'
+            ? 'bg-brand/15 dark:bg-brand/10 text-brand'
+            : 'hover:bg-hover hover:dark:bg-hover/50'
+        )}>
+        All libraries
+      </button>
+      <button
+        onClick={() => setDisplayMode('failing')}
+        className={twMerge(
+          'text-sm font-normal px-3 py-1 rounded text-secondary cursor-pointer transition-colors',
+          displayMode === 'failing'
+            ? 'bg-brand/15 dark:bg-brand/10 text-brand'
+            : 'hover:bg-hover hover:dark:bg-hover/50'
+        )}>
+        Failing
+      </button>
+    </div>
+  );
+}

--- a/website/components/DisplayModeSelector.tsx
+++ b/website/components/DisplayModeSelector.tsx
@@ -7,11 +7,12 @@ export default function DisplayModeSelector() {
   const { displayMode, setDisplayMode } = useSearch();
 
   return (
-    <div className="flex border border-border rounded-lg p-1 gap-1 bg-subtle">
+    <div className="flex border border-border rounded-lg p-1 gap-1 bg-subtle max-lg:w-full">
       <button
         onClick={() => setDisplayMode('all')}
         className={twMerge(
-          'text-sm font-normal px-3 py-1 rounded text-secondary cursor-pointer transition-colors',
+          'text-sm font-normal px-3.5 py-1 rounded text-secondary cursor-pointer transition-colors',
+          'max-lg:w-1/2',
           displayMode === 'all'
             ? 'bg-brand/15 dark:bg-brand/10 text-brand'
             : 'hover:bg-hover hover:dark:bg-hover/50'
@@ -21,7 +22,8 @@ export default function DisplayModeSelector() {
       <button
         onClick={() => setDisplayMode('failing')}
         className={twMerge(
-          'text-sm font-normal px-3 py-1 rounded text-secondary cursor-pointer transition-colors',
+          'text-sm font-normal px-3.5 py-1 rounded text-secondary cursor-pointer transition-colors',
+          'max-lg:w-1/2',
           displayMode === 'failing'
             ? 'bg-brand/15 dark:bg-brand/10 text-brand'
             : 'hover:bg-hover hover:dark:bg-hover/50'

--- a/website/components/Header.tsx
+++ b/website/components/Header.tsx
@@ -30,7 +30,7 @@ export default function Header() {
       <div className="flex flex-row min-h-[58px] items-center gap-6 max-w-[1280px] w-full mx-auto px-4">
         <div className="flex gap-2 items-center">
           <Logo className="text-brand size-8" />
-          <p className="whitespace-nowrap max-sm:hidden">
+          <p className="whitespace-nowrap font-normal max-sm:hidden">
             React Native Nightly Tests
           </p>
           <p className="whitespace-nowrap hidden max-sm:block">RNNT</p>

--- a/website/components/Header.tsx
+++ b/website/components/Header.tsx
@@ -1,17 +1,18 @@
 'use client';
 
-import Link from 'next/link';
-import { useTheme } from 'next-themes';
 import { useEffect, useState, useTransition } from 'react';
+import Link from 'next/link';
 import { twMerge } from 'tailwind-merge';
+import { useTheme } from 'next-themes';
 
 import { useSearch } from '~/context/SearchContext';
+
 import GitHubLogo from '~/public/icons/github-icon.svg';
+import Logo from '~/public/logo.svg';
 import PlusIcon from '~/public/icons/plus-icon.svg';
 import SearchIcon from '~/public/icons/search-icon.svg';
 import ThemeDarkIcon from '~/public/icons/theme-dark-icon.svg';
 import ThemeLightIcon from '~/public/icons/theme-light-icon.svg';
-import Logo from '~/public/logo.svg';
 
 import Tooltip from './Tooltip';
 

--- a/website/components/Table.tsx
+++ b/website/components/Table.tsx
@@ -8,14 +8,16 @@ import {
   getFilteredRowModel,
   useReactTable,
 } from '@tanstack/react-table';
-import { useMemo } from 'react';
 import { twMerge } from 'tailwind-merge';
+import { useMemo } from 'react';
 
 import { DirectoryLink } from '~/components/DirectoryLink';
 import { EntryNotes } from '~/components/EntryNotes';
 import { GitHubRepoLink } from '~/components/GitHubRepoLink';
 import { useSearch } from '~/context/SearchContext';
+
 import data from '~/public/data.json';
+
 import { type LibraryType, PlatformStatus } from '~/types/data-types';
 import getCleanPackageName from '~/utils/getCleanPackageName';
 

--- a/website/components/Table.tsx
+++ b/website/components/Table.tsx
@@ -8,6 +8,7 @@ import {
   getFilteredRowModel,
   useReactTable,
 } from '@tanstack/react-table';
+import { useMemo } from 'react';
 import { twMerge } from 'tailwind-merge';
 
 import { DirectoryLink } from '~/components/DirectoryLink';
@@ -21,6 +22,10 @@ import getCleanPackageName from '~/utils/getCleanPackageName';
 import Tooltip from './Tooltip';
 
 const columnHelper = createColumnHelper<LibraryType>();
+const tableRows = data as LibraryType[];
+const resultDates = Object.keys(
+  tableRows[tableRows.length - 1].results
+).reverse();
 
 function formatStatus(info: CellContext<LibraryType, PlatformStatus>) {
   switch (info.getValue()) {
@@ -50,69 +55,81 @@ type Props = {
 };
 
 export default function Table({ platform }: Props) {
-  const { query } = useSearch();
+  const { query, displayMode } = useSearch();
+  const firstResultDate = resultDates[0];
+  const tableData = useMemo(
+    () =>
+      displayMode === 'failing'
+        ? tableRows.filter(
+            row => row.results?.[firstResultDate]?.[platform] === 'failure'
+          )
+        : tableRows,
+    [displayMode, firstResultDate, platform]
+  );
 
-  const columns = [
-    columnHelper.accessor(`installCommand`, {
-      header: () => <span className="block">Library</span>,
-      cell: info => {
-        const entry = info.getValue();
-        const notes = info.row.original.notes;
+  const columns = useMemo(
+    () => [
+      columnHelper.accessor(`installCommand`, {
+        header: () => <span className="block">Library</span>,
+        cell: info => {
+          const entry = info.getValue();
+          const notes = info.row.original.notes;
 
-        if (!entry.includes(' ')) {
-          const packageName = getCleanPackageName(entry);
-          const repositoryURL = info.row.original.repositoryURLs?.[packageName];
-          return (
-            <div className="flex items-center gap-1.5">
-              {entry}
-              <div className="flex items-center gap-1.5 ml-auto">
-                <EntryNotes notes={notes} />
-                <DirectoryLink
-                  packageName={repositoryURL ? packageName : undefined}
-                />
-                <GitHubRepoLink repositoryURL={repositoryURL} />
+          if (!entry.includes(' ')) {
+            const packageName = getCleanPackageName(entry);
+            const repositoryURL =
+              info.row.original.repositoryURLs?.[packageName];
+            return (
+              <div className="flex items-center gap-1.5">
+                {entry}
+                <div className="flex items-center gap-1.5 ml-auto">
+                  <EntryNotes notes={notes} />
+                  <DirectoryLink
+                    packageName={repositoryURL ? packageName : undefined}
+                  />
+                  <GitHubRepoLink repositoryURL={repositoryURL} />
+                </div>
               </div>
+            );
+          }
+
+          return (
+            <div className="flex flex-col">
+              {entry.split(' ').map((lib: string) => {
+                const packageName = getCleanPackageName(lib);
+                const repositoryURL =
+                  info.row.original.repositoryURLs?.[packageName];
+                return (
+                  <div className="flex items-center gap-1.5" key={lib}>
+                    {lib}
+                    <div className="flex items-center gap-1.5 ml-auto">
+                      <EntryNotes notes={notes} />
+                      <DirectoryLink
+                        packageName={repositoryURL ? packageName : undefined}
+                      />
+                      <GitHubRepoLink repositoryURL={repositoryURL} />
+                    </div>
+                  </div>
+                );
+              })}
             </div>
           );
-        }
-
-        return (
-          <div className="flex flex-col">
-            {entry.split(' ').map((lib: string) => {
-              const packageName = getCleanPackageName(lib);
-              const repositoryURL =
-                info.row.original.repositoryURLs?.[packageName];
-              return (
-                <div className="flex items-center gap-1.5" key={lib}>
-                  {lib}
-                  <div className="flex items-center gap-1.5 ml-auto">
-                    <EntryNotes notes={notes} />
-                    <DirectoryLink
-                      packageName={repositoryURL ? packageName : undefined}
-                    />
-                    <GitHubRepoLink repositoryURL={repositoryURL} />
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        );
-      },
-      filterFn: 'includesString',
-    }),
-    ...Object.keys(data[data.length - 1].results)
-      .reverse()
-      .map(date =>
+        },
+        filterFn: 'includesString',
+      }),
+      ...resultDates.map(date =>
         columnHelper.accessor(row => row.results?.[date]?.[platform], {
           id: `results.${date}.${platform}`,
           header: () => <span className="block text-xs">{date}</span>,
           cell: formatStatus,
         })
       ),
-  ];
+    ],
+    [platform]
+  );
 
   const table = useReactTable({
-    data: data as LibraryType[],
+    data: tableData,
     columns,
     state: {
       globalFilter: query,

--- a/website/components/Tooltip.tsx
+++ b/website/components/Tooltip.tsx
@@ -1,12 +1,12 @@
 import {
+  Arrow,
+  Content,
+  Portal,
   Provider,
   Root,
-  Trigger,
-  Portal,
-  Content,
-  Arrow,
-  type TooltipProps,
   type TooltipContentProps,
+  type TooltipProps,
+  Trigger,
 } from '@radix-ui/react-tooltip';
 import { type ReactNode } from 'react';
 

--- a/website/context/SearchContext.tsx
+++ b/website/context/SearchContext.tsx
@@ -11,10 +11,17 @@ import {
   useRef,
   useState,
 } from 'react';
+import { DisplayMode } from '~/types/data-types';
+
+function parseDisplayMode(value: string | null): DisplayMode {
+  return value === 'failing' ? 'failing' : 'all';
+}
 
 type SearchContextValue = {
   query: string;
   setQuery: Dispatch<SetStateAction<string>>;
+  displayMode: DisplayMode;
+  setDisplayMode: Dispatch<SetStateAction<DisplayMode>>;
 };
 
 const SearchContext = createContext<SearchContextValue | undefined>(undefined);
@@ -25,7 +32,11 @@ export function SearchProvider({ children }: PropsWithChildren) {
   const searchParams = useSearchParams();
 
   const [query, setQuery] = useState(searchParams.get('q') ?? '');
+  const [displayMode, setDisplayMode] = useState<DisplayMode>(() =>
+    parseDisplayMode(searchParams.get('mode'))
+  );
   const previousQueryRef = useRef<string>(query);
+  const previousDisplayModeRef = useRef<DisplayMode>(displayMode);
 
   useEffect(() => {
     const searchParamsQuery = searchParams.get('q') ?? '';
@@ -40,8 +51,26 @@ export function SearchProvider({ children }: PropsWithChildren) {
   }, [searchParams, query]);
 
   useEffect(() => {
+    const searchParamsDisplayMode = parseDisplayMode(searchParams.get('mode'));
+    if (
+      searchParamsDisplayMode === previousDisplayModeRef.current ||
+      searchParamsDisplayMode === displayMode
+    ) {
+      return;
+    }
+
+    setDisplayMode(searchParamsDisplayMode);
+  }, [displayMode, searchParams]);
+
+  useEffect(() => {
     const searchParamsQuery = searchParams.get('q') ?? '';
-    if (query === searchParamsQuery) {
+    const searchParamsDisplayMode = searchParams.get('mode');
+    const expectedDisplayModeParam = displayMode === 'all' ? null : displayMode;
+
+    if (
+      query === searchParamsQuery &&
+      searchParamsDisplayMode === expectedDisplayModeParam
+    ) {
       return;
     }
 
@@ -52,16 +81,24 @@ export function SearchProvider({ children }: PropsWithChildren) {
       newSearchParams.delete('q');
     }
 
+    if (displayMode === 'all') {
+      newSearchParams.delete('mode');
+    } else {
+      newSearchParams.set('mode', displayMode);
+    }
+
     previousQueryRef.current = query;
+    previousDisplayModeRef.current = displayMode;
 
     const queryString = newSearchParams.toString();
     router.replace(queryString ? `${pathname}?${queryString}` : pathname, {
       scroll: false,
     });
-  }, [query, pathname, router, searchParams]);
+  }, [displayMode, query, pathname, router, searchParams]);
 
   return (
-    <SearchContext.Provider value={{ query, setQuery }}>
+    <SearchContext.Provider
+      value={{ query, setQuery, displayMode, setDisplayMode }}>
       {children}
     </SearchContext.Provider>
   );

--- a/website/context/SearchContext.tsx
+++ b/website/context/SearchContext.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import {
   Dispatch,
   PropsWithChildren,
@@ -11,6 +10,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { DisplayMode } from '~/types/data-types';
 
 function parseDisplayMode(value: string | null): DisplayMode {

--- a/website/eslint.config.mjs
+++ b/website/eslint.config.mjs
@@ -1,8 +1,8 @@
-import nextPlugin from '@next/eslint-plugin-next';
 import { defineConfig, globalIgnores } from 'eslint/config';
-import importPlugin from 'eslint-plugin-import';
-import reactPlugin from 'eslint-plugin-react';
 import { parserPlain, plugin as pluginSVGO } from 'eslint-plugin-svgo';
+import importPlugin from 'eslint-plugin-import';
+import nextPlugin from '@next/eslint-plugin-next';
+import reactPlugin from 'eslint-plugin-react';
 import typescriptESLint from 'typescript-eslint';
 
 import rootConfig from '../eslint.config.mjs';
@@ -30,25 +30,16 @@ export default defineConfig([
       ...nextPlugin.configs.recommended.rules,
       ...nextPlugin.configs['core-web-vitals'].rules,
 
+      'sort-imports': [
+        'error',
+        {
+          allowSeparatedGroups: true,
+        },
+      ],
+
       '@next/next/no-img-element': 'off',
 
       'import/no-unresolved': 'off',
-      'import/order': [
-        'error',
-        {
-          groups: [['external', 'builtin'], 'internal', ['parent', 'sibling']],
-          'newlines-between': 'always',
-          alphabetize: {
-            order: 'asc',
-          },
-          pathGroups: [
-            {
-              pattern: '~/**',
-              group: 'internal',
-            },
-          ],
-        },
-      ],
     },
     languageOptions: {
       parser: typescriptESLint.parser,

--- a/website/public/data.json
+++ b/website/public/data.json
@@ -7,31 +7,32 @@
     },
     "notes": "",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27003713404",
+        "ios": "success"
+      },
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
-        "android": "success",
-        "ios": "success"
-      },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -45,31 +46,31 @@
     },
     "notes": "",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -83,32 +84,74 @@
     },
     "notes": "Additional OSS libs used internally",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
+        "ios": "success"
+      }
+    }
+  },
+  {
+    "library": "@maplibre/maplibre-react-native",
+    "installCommand": "@maplibre/maplibre-react-native",
+    "repositoryURLs": {
+      "@maplibre/maplibre-react-native": "https://github.com/maplibre/maplibre-react-native/tree/main/package"
+    },
+    "notes": "",
+    "results": {
+      "2026-05-31": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2026-06-01": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2026-06-02": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2026-06-04": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/26965384533",
+        "ios": "success"
+      },
+      "2026-06-05": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27003713404",
+        "ios": "success"
+      },
+      "2026-06-06": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27056124208",
+        "ios": "success"
+      },
+      "2026-06-08": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27126981819",
         "ios": "success"
       }
     }
@@ -121,31 +164,32 @@
     },
     "notes": "One of top most used libraries according to the npm stats",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/26706964841",
+        "ios": "success"
+      },
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
-        "android": "success",
-        "ios": "success"
-      },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -159,31 +203,32 @@
     },
     "notes": "",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
-        "android": "success",
+      "2026-06-06": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27056124208",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -197,32 +242,34 @@
     },
     "notes": "",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27003713404",
+        "ios": "success"
+      },
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
-        "android": "success",
-        "ios": "success"
-      },
-      "2026-05-13": {
-        "android": "success",
+      "2026-06-08": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27126981819",
         "ios": "success"
       }
     }
@@ -235,31 +282,32 @@
     },
     "notes": "Additional OSS libs used internally",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27003713404",
+        "ios": "success"
+      },
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
-        "android": "success",
-        "ios": "success"
-      },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -273,31 +321,32 @@
     },
     "notes": "",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
-        "android": "success",
+      "2026-06-06": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27056124208",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -311,31 +360,32 @@
     },
     "notes": "",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
-        "android": "success",
+      "2026-06-06": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27056124208",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -349,31 +399,31 @@
     },
     "notes": "",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -387,31 +437,31 @@
     },
     "notes": "",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -425,31 +475,31 @@
     },
     "notes": "",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -463,31 +513,31 @@
     },
     "notes": "One of top most used libraries according to the npm stats",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -501,33 +551,38 @@
     },
     "notes": "One of top most used libraries according to the npm stats",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
-        "ios": "success"
+        "ios": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/26808778947"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
-        "ios": "success"
+        "ios": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/26965384533"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
-        "ios": "success"
+        "ios": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27003713404"
       },
-      "2026-05-12": {
+      "2026-06-06": {
         "android": "success",
-        "ios": "success"
+        "ios": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27056124208"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
-        "ios": "success"
+        "ios": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27126981819"
       }
     }
   },
@@ -539,33 +594,40 @@
     },
     "notes": "One of top most used libraries according to the npm stats",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
-        "ios": "success"
+        "ios": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/26706964841"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
-        "ios": "success"
+        "ios": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/26749466136"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
-        "ios": "success"
+        "ios": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/26808778947"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
-        "ios": "success"
+        "ios": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/26965384533"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
-        "ios": "success"
+        "ios": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27003713404"
       },
-      "2026-05-12": {
+      "2026-06-06": {
         "android": "success",
-        "ios": "success"
+        "ios": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27056124208"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
-        "ios": "success"
+        "ios": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27126981819"
       }
     }
   },
@@ -577,31 +639,31 @@
     },
     "notes": "One of top most used libraries according to the npm stats",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -615,31 +677,31 @@
     },
     "notes": "One of top most used libraries according to the npm stats",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -650,31 +712,31 @@
     "installCommand": "react-native-async-storage",
     "notes": "",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -688,31 +750,32 @@
     },
     "notes": "",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
-        "android": "success",
+      "2026-06-06": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27056124208",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -726,31 +789,31 @@
     },
     "notes": "One of top most used libraries according to the npm stats",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -764,31 +827,31 @@
     },
     "notes": "Additional OSS libs used internally",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -802,31 +865,31 @@
     },
     "notes": "Additional OSS libs used internally",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -840,31 +903,31 @@
     },
     "notes": "One of top most used libraries according to the npm stats",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -878,31 +941,66 @@
     },
     "notes": "Additional OSS libs used internally",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
+      "2026-06-06": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27056124208",
+        "ios": "success"
+      },
+      "2026-06-08": {
+        "android": "success",
+        "ios": "success"
+      }
+    }
+  },
+  {
+    "library": "react-native-enriched-markdown",
+    "installCommand": "react-native-enriched-markdown@nightly",
+    "repositoryURLs": {
+      "react-native-enriched-markdown": "https://github.com/software-mansion/react-native-enriched-markdown"
+    },
+    "notes": "",
+    "results": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-02": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2026-06-04": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2026-06-05": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2026-06-06": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -916,31 +1014,31 @@
     },
     "notes": "",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -954,34 +1052,38 @@
     },
     "notes": "",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2026-06-02": {
+        "android": "success",
+        "ios": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/26808778947"
+      },
+      "2026-06-04": {
+        "android": "success",
+        "ios": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/26965384533"
+      },
+      "2026-06-05": {
+        "android": "success",
+        "ios": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27003713404"
+      },
+      "2026-06-06": {
         "android": "failure",
-        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/25539932875",
-        "ios": "success"
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27056124208",
+        "ios": "failure"
       },
-      "2026-05-09": {
+      "2026-06-08": {
         "android": "success",
-        "ios": "success"
-      },
-      "2026-05-10": {
-        "android": "success",
-        "ios": "success"
-      },
-      "2026-05-11": {
-        "android": "success",
-        "ios": "success"
-      },
-      "2026-05-12": {
-        "android": "success",
-        "ios": "success"
-      },
-      "2026-05-13": {
-        "android": "success",
-        "ios": "success"
+        "ios": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27126981819"
       }
     }
   },
@@ -994,31 +1096,31 @@
     },
     "notes": "",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -1032,31 +1134,33 @@
     },
     "notes": "",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/26965384533",
+        "ios": "success"
+      },
+      "2026-06-05": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27003713404",
+        "ios": "success"
+      },
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
-        "android": "success",
-        "ios": "success"
-      },
-      "2026-05-12": {
-        "android": "success",
-        "ios": "success"
-      },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -1070,32 +1174,38 @@
     },
     "notes": "One of top most used libraries according to the npm stats",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/26706964841",
+        "ios": "success"
+      },
+      "2026-06-01": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/26749466136",
+        "ios": "success"
+      },
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
-        "android": "success",
+      "2026-06-04": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/26965384533",
         "ios": "success"
       },
-      "2026-05-09": {
-        "android": "success",
+      "2026-06-05": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27003713404",
         "ios": "success"
       },
-      "2026-05-10": {
-        "android": "success",
+      "2026-06-06": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27056124208",
         "ios": "success"
       },
-      "2026-05-11": {
-        "android": "success",
-        "ios": "success"
-      },
-      "2026-05-12": {
-        "android": "success",
-        "ios": "success"
-      },
-      "2026-05-13": {
-        "android": "success",
+      "2026-06-08": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27126981819",
         "ios": "success"
       }
     }
@@ -1108,31 +1218,31 @@
     },
     "notes": "",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -1146,31 +1256,32 @@
     },
     "notes": "One of top most used libraries according to the npm stats",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
-        "android": "success",
+      "2026-06-06": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27056124208",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -1184,31 +1295,31 @@
     },
     "notes": "One of top most used libraries according to the npm stats",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -1219,31 +1330,31 @@
     "installCommand": "react-native-masked-view",
     "notes": "Additional OSS libs used internally",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -1258,31 +1369,70 @@
     },
     "notes": "",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
+        "android": "success",
+        "ios": "success"
+      }
+    }
+  },
+  {
+    "library": "react-native-nitro-fetch",
+    "installCommand": "react-native-nitro-fetch react-native-nitro-modules",
+    "repositoryURLs": {
+      "react-native-nitro-fetch": "https://github.com/margelo/react-native-nitro-fetch/tree/main/packages/react-native-nitro-fetch",
+      "react-native-nitro-modules": "https://github.com/mrousavy/nitro/tree/main/packages/react-native-nitro-modules"
+    },
+    "notes": "",
+    "results": {
+      "2026-05-31": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2026-06-01": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2026-06-02": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2026-06-04": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2026-06-05": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2026-06-06": {
+        "android": "success",
+        "ios": "success"
+      },
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -1296,31 +1446,32 @@
     },
     "notes": "",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
-        "android": "success",
+      "2026-06-06": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27056124208",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -1335,31 +1486,31 @@
     },
     "notes": "",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -1373,31 +1524,31 @@
     },
     "notes": "",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -1411,31 +1562,32 @@
     },
     "notes": "",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
-        "android": "success",
+      "2026-06-06": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27056124208",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -1449,31 +1601,31 @@
     },
     "notes": "Additional OSS libs used internally",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -1488,32 +1640,37 @@
     },
     "notes": "",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
-        "android": "success",
+      "2026-06-02": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/26808778947",
         "ios": "success"
       },
-      "2026-05-10": {
-        "android": "success",
+      "2026-06-04": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/26965384533",
         "ios": "success"
       },
-      "2026-05-11": {
-        "android": "success",
+      "2026-06-05": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27003713404",
         "ios": "success"
       },
-      "2026-05-12": {
-        "android": "success",
+      "2026-06-06": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27056124208",
         "ios": "success"
       },
-      "2026-05-13": {
-        "android": "success",
+      "2026-06-08": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27126981819",
         "ios": "success"
       }
     }
@@ -1526,31 +1683,31 @@
     },
     "notes": "A popular library for React Native projects built with the New Architecture.",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -1564,33 +1721,40 @@
     },
     "notes": "",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
-        "ios": "success"
+        "ios": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/26706964841"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
-        "ios": "success"
+        "ios": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/26749466136"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
-        "ios": "success"
+        "ios": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/26808778947"
       },
-      "2026-05-10": {
-        "android": "success",
-        "ios": "success"
+      "2026-06-04": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/26965384533",
+        "ios": "failure"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
-        "ios": "success"
+        "ios": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27003713404"
       },
-      "2026-05-12": {
+      "2026-06-06": {
         "android": "success",
-        "ios": "success"
+        "ios": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27056124208"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
-        "ios": "success"
+        "ios": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27126981819"
       }
     }
   },
@@ -1602,31 +1766,32 @@
     },
     "notes": "One of top most used libraries according to the npm stats",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27003713404",
+        "ios": "success"
+      },
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
-        "android": "success",
-        "ios": "success"
-      },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -1640,31 +1805,32 @@
     },
     "notes": "",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27003713404",
+        "ios": "success"
+      },
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
-        "android": "success",
-        "ios": "success"
-      },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -1680,31 +1846,32 @@
     },
     "notes": "Popular styling library for React Native",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
-        "android": "success",
+      "2026-06-06": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27056124208",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -1715,31 +1882,32 @@
     "installCommand": "react-native-vector-icons",
     "notes": "Additional OSS libs used internally",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
-        "android": "success",
+      "2026-06-06": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27056124208",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -1753,31 +1921,31 @@
     },
     "notes": "",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -1785,37 +1953,39 @@
   },
   {
     "library": "react-native-vision-camera",
-    "installCommand": "react-native-vision-camera",
+    "installCommand": "react-native-vision-camera react-native-nitro-modules react-native-nitro-image",
     "repositoryURLs": {
-      "react-native-vision-camera": "https://github.com/mrousavy/react-native-vision-camera/tree/main/packages/react-native-vision-camera"
+      "react-native-vision-camera": "https://github.com/mrousavy/react-native-vision-camera/tree/main/packages/react-native-vision-camera",
+      "react-native-nitro-modules": "https://github.com/mrousavy/nitro/tree/main/packages/react-native-nitro-modules",
+      "react-native-nitro-image": "https://github.com/mrousavy/react-native-nitro-image/tree/main/packages/react-native-nitro-image"
     },
     "notes": "One of top most used libraries according to the npm stats",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -1829,31 +1999,31 @@
     },
     "notes": "",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -1867,31 +2037,32 @@
     },
     "notes": "",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
-        "android": "success",
+      "2026-06-06": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/27056124208",
         "ios": "success"
       },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }
@@ -1906,31 +2077,32 @@
     },
     "notes": "Additional OSS libs used internally",
     "results": {
-      "2026-05-07": {
+      "2026-05-31": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-08": {
+      "2026-06-01": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-09": {
+      "2026-06-02": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-10": {
+      "2026-06-04": {
+        "android": "failure",
+        "runUrl": "https://github.com/react-native-community/nightly-tests/actions/runs/26965384533",
+        "ios": "success"
+      },
+      "2026-06-05": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-11": {
+      "2026-06-06": {
         "android": "success",
         "ios": "success"
       },
-      "2026-05-12": {
-        "android": "success",
-        "ios": "success"
-      },
-      "2026-05-13": {
+      "2026-06-08": {
         "android": "success",
         "ios": "success"
       }

--- a/website/scripts/fetch-data.mjs
+++ b/website/scripts/fetch-data.mjs
@@ -1,7 +1,7 @@
+import { cert, initializeApp } from 'firebase-admin';
 import dotenv from 'dotenv';
-import { initializeApp, cert } from 'firebase-admin';
-import { getDatabase } from 'firebase-admin/database';
 import fs from 'node:fs/promises';
+import { getDatabase } from 'firebase-admin/database';
 import path from 'node:path';
 
 const DAYS_TO_SHOW = 7;

--- a/website/scripts/fetch-data.mjs
+++ b/website/scripts/fetch-data.mjs
@@ -1,5 +1,6 @@
 import dotenv from 'dotenv';
-import firebase from 'firebase-admin';
+import { initializeApp, cert } from 'firebase-admin';
+import { getDatabase } from 'firebase-admin/database';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
@@ -45,12 +46,12 @@ function getCleanPackageName(packageName) {
 }
 
 async function main() {
-  firebase.initializeApp({
-    credential: firebase.credential.cert(credential),
+  initializeApp({
+    credential: cert(credential),
     databaseURL: `https://${process.env.FIREBASE_APP_PROJECTNAME}.firebaseio.com`,
   });
 
-  const rootDb = firebase.database().ref('/');
+  const rootDb = getDatabase().ref('/');
   const snapshot = await rootDb.once('value');
   const data = snapshot.val() ?? {};
 

--- a/website/styles/globals.css
+++ b/website/styles/globals.css
@@ -39,8 +39,12 @@
 
 /* Global styles */
 
+html {
+  @apply scrollbar-thin scrollbar-thumb-secondary scrollbar-track-transparent;
+}
+
 body {
-  @apply selection:bg-(--selection);
+  @apply selection:bg-(--selection) font-light;
 }
 
 * {

--- a/website/types/data-types.ts
+++ b/website/types/data-types.ts
@@ -13,4 +13,6 @@ export type LibraryType = {
   >;
 };
 
+export type DisplayMode = 'all' | 'failing';
+
 export type PlatformStatus = 'success' | 'failure' | undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1839,12 +1839,12 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.5.tgz#d9315ad7cf3f30aac70bda3c068443dc6f143659"
   integrity sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==
 
-"@protobufjs/eventemitter@^1.1.0", "@protobufjs/eventemitter@^1.1.1":
+"@protobufjs/eventemitter@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz#d512cb26c0ae026091ee2c1167f1be6faf5c842a"
   integrity sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==
 
-"@protobufjs/fetch@^1.1.0", "@protobufjs/fetch@^1.1.1":
+"@protobufjs/fetch@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.1.tgz#4d6fc00c8fb64016a5c81b469d549046350f1065"
   integrity sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==
@@ -1855,11 +1855,6 @@
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
   integrity sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==
-
-"@protobufjs/inquire@^1.1.0", "@protobufjs/inquire@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.1.tgz#6cb936f4ac50965230af1e9d0bbfd57ea3675aa4"
-  integrity sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==
 
 "@protobufjs/path@^1.1.2":
   version "1.1.2"
@@ -2486,38 +2481,29 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@8.61.0":
-  version "8.61.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.0.tgz#db20271974b94a3a54d3b9544e5f5b3481448400"
-  integrity sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==
+"@typescript-eslint/eslint-plugin@8.61.1":
+  version "8.61.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.1.tgz#6e4b7fee21f1983308e9e9b634ecbaf702c86006"
+  integrity sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==
   dependencies:
     "@eslint-community/regexpp" "^4.12.2"
-    "@typescript-eslint/scope-manager" "8.61.0"
-    "@typescript-eslint/type-utils" "8.61.0"
-    "@typescript-eslint/utils" "8.61.0"
-    "@typescript-eslint/visitor-keys" "8.61.0"
+    "@typescript-eslint/scope-manager" "8.61.1"
+    "@typescript-eslint/type-utils" "8.61.1"
+    "@typescript-eslint/utils" "8.61.1"
+    "@typescript-eslint/visitor-keys" "8.61.1"
     ignore "^7.0.5"
     natural-compare "^1.4.0"
     ts-api-utils "^2.5.0"
 
-"@typescript-eslint/parser@8.61.0":
-  version "8.61.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.61.0.tgz#1afe73c9ccce16b7a26d6b95f9400b0ccc34af87"
-  integrity sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==
+"@typescript-eslint/parser@8.61.1":
+  version "8.61.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.61.1.tgz#881fba60b50636249cdeea2e547bf75715254c72"
+  integrity sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==
   dependencies:
-    "@typescript-eslint/scope-manager" "8.61.0"
-    "@typescript-eslint/types" "8.61.0"
-    "@typescript-eslint/typescript-estree" "8.61.0"
-    "@typescript-eslint/visitor-keys" "8.61.0"
-    debug "^4.4.3"
-
-"@typescript-eslint/project-service@8.60.1":
-  version "8.60.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/project-service/-/project-service-8.60.1.tgz#eb29712f58d72c222fc727162e92f2ab4670971b"
-  integrity sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==
-  dependencies:
-    "@typescript-eslint/tsconfig-utils" "^8.60.1"
-    "@typescript-eslint/types" "^8.60.1"
+    "@typescript-eslint/scope-manager" "8.61.1"
+    "@typescript-eslint/types" "8.61.1"
+    "@typescript-eslint/typescript-estree" "8.61.1"
+    "@typescript-eslint/visitor-keys" "8.61.1"
     debug "^4.4.3"
 
 "@typescript-eslint/project-service@8.61.0":
@@ -2529,13 +2515,14 @@
     "@typescript-eslint/types" "^8.61.0"
     debug "^4.4.3"
 
-"@typescript-eslint/scope-manager@8.60.1":
-  version "8.60.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.60.1.tgz#2f875962eaad0a0789cc3c36aea9b4ddeb2dd9c8"
-  integrity sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==
+"@typescript-eslint/project-service@8.61.1":
+  version "8.61.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/project-service/-/project-service-8.61.1.tgz#fcd9739964a40867eed55f1ac318d3909f24b4af"
+  integrity sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==
   dependencies:
-    "@typescript-eslint/types" "8.60.1"
-    "@typescript-eslint/visitor-keys" "8.60.1"
+    "@typescript-eslint/tsconfig-utils" "^8.61.1"
+    "@typescript-eslint/types" "^8.61.1"
+    debug "^4.4.3"
 
 "@typescript-eslint/scope-manager@8.61.0":
   version "8.61.0"
@@ -2545,51 +2532,44 @@
     "@typescript-eslint/types" "8.61.0"
     "@typescript-eslint/visitor-keys" "8.61.0"
 
-"@typescript-eslint/tsconfig-utils@8.60.1":
-  version "8.60.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.1.tgz#bee8b942a13679a878101c9c74577d732062ed93"
-  integrity sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA==
+"@typescript-eslint/scope-manager@8.61.1":
+  version "8.61.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.61.1.tgz#2479921a40fdb0afa18f5838fae6167264b417b2"
+  integrity sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==
+  dependencies:
+    "@typescript-eslint/types" "8.61.1"
+    "@typescript-eslint/visitor-keys" "8.61.1"
 
-"@typescript-eslint/tsconfig-utils@8.61.0", "@typescript-eslint/tsconfig-utils@^8.60.1", "@typescript-eslint/tsconfig-utils@^8.61.0":
+"@typescript-eslint/tsconfig-utils@8.61.0":
   version "8.61.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.0.tgz#05d6e3ff20001674ebcd22d03dac29ee448043ba"
   integrity sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==
 
-"@typescript-eslint/type-utils@8.61.0":
-  version "8.61.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-8.61.0.tgz#50219b57e6b89cecfb1a15f093b15ec9ee019974"
-  integrity sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==
+"@typescript-eslint/tsconfig-utils@8.61.1", "@typescript-eslint/tsconfig-utils@^8.61.0", "@typescript-eslint/tsconfig-utils@^8.61.1":
+  version "8.61.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.1.tgz#ca88080e0cf191d49516d7f300b67aa090d2254f"
+  integrity sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==
+
+"@typescript-eslint/type-utils@8.61.1":
+  version "8.61.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-8.61.1.tgz#8fa18f453ee140893b47d339d1a6b64cac9b08a1"
+  integrity sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw==
   dependencies:
-    "@typescript-eslint/types" "8.61.0"
-    "@typescript-eslint/typescript-estree" "8.61.0"
-    "@typescript-eslint/utils" "8.61.0"
+    "@typescript-eslint/types" "8.61.1"
+    "@typescript-eslint/typescript-estree" "8.61.1"
+    "@typescript-eslint/utils" "8.61.1"
     debug "^4.4.3"
     ts-api-utils "^2.5.0"
 
-"@typescript-eslint/types@8.60.1":
-  version "8.60.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.60.1.tgz#ccdc482ba9e17f9723a10ce240b5e67dad3046c4"
-  integrity sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==
-
-"@typescript-eslint/types@8.61.0", "@typescript-eslint/types@^8.60.1", "@typescript-eslint/types@^8.61.0":
+"@typescript-eslint/types@8.61.0":
   version "8.61.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.61.0.tgz#0ddb46e012a4288292950bdd253db42f278ce64d"
   integrity sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==
 
-"@typescript-eslint/typescript-estree@8.60.1":
-  version "8.60.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.1.tgz#016630b119228bf483ddc652703a6a038f3fdd74"
-  integrity sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew==
-  dependencies:
-    "@typescript-eslint/project-service" "8.60.1"
-    "@typescript-eslint/tsconfig-utils" "8.60.1"
-    "@typescript-eslint/types" "8.60.1"
-    "@typescript-eslint/visitor-keys" "8.60.1"
-    debug "^4.4.3"
-    minimatch "^10.2.2"
-    semver "^7.7.3"
-    tinyglobby "^0.2.15"
-    ts-api-utils "^2.5.0"
+"@typescript-eslint/types@8.61.1", "@typescript-eslint/types@^8.61.0", "@typescript-eslint/types@^8.61.1":
+  version "8.61.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.61.1.tgz#0c51f518e4e6848371a1c988e859d59eb7522d5a"
+  integrity sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==
 
 "@typescript-eslint/typescript-estree@8.61.0":
   version "8.61.0"
@@ -2606,23 +2586,30 @@
     tinyglobby "^0.2.15"
     ts-api-utils "^2.5.0"
 
-"@typescript-eslint/utils@8.61.0", "@typescript-eslint/utils@^8.0.0":
-  version "8.61.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.61.0.tgz#ed3546a052787e84ea6c5064d0919fc5eea8522f"
-  integrity sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==
+"@typescript-eslint/typescript-estree@8.61.1":
+  version "8.61.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.1.tgz#febbe70365ac0bf7611262b61b338fc8797965c7"
+  integrity sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==
+  dependencies:
+    "@typescript-eslint/project-service" "8.61.1"
+    "@typescript-eslint/tsconfig-utils" "8.61.1"
+    "@typescript-eslint/types" "8.61.1"
+    "@typescript-eslint/visitor-keys" "8.61.1"
+    debug "^4.4.3"
+    minimatch "^10.2.2"
+    semver "^7.7.3"
+    tinyglobby "^0.2.15"
+    ts-api-utils "^2.5.0"
+
+"@typescript-eslint/utils@8.61.1", "@typescript-eslint/utils@^8.0.0":
+  version "8.61.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.61.1.tgz#ffd1054de7dd33b7873cd6c6713ec6b0366316d3"
+  integrity sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==
   dependencies:
     "@eslint-community/eslint-utils" "^4.9.1"
-    "@typescript-eslint/scope-manager" "8.61.0"
-    "@typescript-eslint/types" "8.61.0"
-    "@typescript-eslint/typescript-estree" "8.61.0"
-
-"@typescript-eslint/visitor-keys@8.60.1":
-  version "8.60.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.1.tgz#165d1d8901137b944efaf18f00ab5ecb57f06995"
-  integrity sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==
-  dependencies:
-    "@typescript-eslint/types" "8.60.1"
-    eslint-visitor-keys "^5.0.0"
+    "@typescript-eslint/scope-manager" "8.61.1"
+    "@typescript-eslint/types" "8.61.1"
+    "@typescript-eslint/typescript-estree" "8.61.1"
 
 "@typescript-eslint/visitor-keys@8.61.0":
   version "8.61.0"
@@ -2630,6 +2617,14 @@
   integrity sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==
   dependencies:
     "@typescript-eslint/types" "8.61.0"
+    eslint-visitor-keys "^5.0.0"
+
+"@typescript-eslint/visitor-keys@8.61.1":
+  version "8.61.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.1.tgz#546cf102b4efdb72a9a08e63a1b0d7d745eb66eb"
+  integrity sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==
+  dependencies:
+    "@typescript-eslint/types" "8.61.1"
     eslint-visitor-keys "^5.0.0"
 
 "@ungap/structured-clone@^1.3.0":
@@ -3851,10 +3846,10 @@ eslint-visitor-keys@^5.0.0, eslint-visitor-keys@^5.0.1:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz#9e3c9489697824d2d4ce3a8ad12628f91e9f59be"
   integrity sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==
 
-eslint@^10.4.1:
-  version "10.4.1"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-10.4.1.tgz#f6640b176e0912246d9ddbf8fcfa5e8b7f02445a"
-  integrity sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==
+eslint@^10.5.0:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-10.5.0.tgz#5fca69d6b41fe7e00ba22d4100b2e44efe439ad5"
+  integrity sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==
   dependencies:
     "@eslint-community/eslint-utils" "^4.8.0"
     "@eslint-community/regexpp" "^4.12.2"
@@ -7381,15 +7376,15 @@ typed-array-length@^1.0.7:
     possible-typed-array-names "^1.0.0"
     reflect.getprototypeof "^1.0.6"
 
-typescript-eslint@^8.61.0:
-  version "8.61.0"
-  resolved "https://registry.yarnpkg.com/typescript-eslint/-/typescript-eslint-8.61.0.tgz#6927fb94f5f29623e370d33fd9fa61f15d6d996b"
-  integrity sha512-8y31Rd0eGTrDKqhy6vT0HtzhN+YLjQizwX3aA3hPXP/ynSfnrBXcQY5IzsP9/DM7+klX4IUncZZjkchP0z+rUw==
+typescript-eslint@^8.61.1:
+  version "8.61.1"
+  resolved "https://registry.yarnpkg.com/typescript-eslint/-/typescript-eslint-8.61.1.tgz#7c224a9a643b7f42d295c67a75c1e30fee8c3eaa"
+  integrity sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==
   dependencies:
-    "@typescript-eslint/eslint-plugin" "8.61.0"
-    "@typescript-eslint/parser" "8.61.0"
-    "@typescript-eslint/typescript-estree" "8.61.0"
-    "@typescript-eslint/utils" "8.61.0"
+    "@typescript-eslint/eslint-plugin" "8.61.1"
+    "@typescript-eslint/parser" "8.61.1"
+    "@typescript-eslint/typescript-estree" "8.61.1"
+    "@typescript-eslint/utils" "8.61.1"
 
 typescript@^6.0.3:
   version "6.0.3"


### PR DESCRIPTION
# Why

With libraries list growing it might be handy to filter out only ones which failed in the recent run.

# How

Add display mode filter which allow to show only packages which has been failing in the last day.

Fix Firebase local data fetch after upgrade to v14, small style tweaks and fixes, update lint dependencies.

# Preview

<img width="2069" height="931" alt="Screenshot 2026-06-17 161206" src="https://github.com/user-attachments/assets/e74c5e6b-86a4-41aa-8fe6-ae99fdbe524e" />

<img width="2083" height="957" alt="Screenshot 2026-06-17 162523" src="https://github.com/user-attachments/assets/08310adc-bf93-4476-b9e9-0db277a736ba" />
