### PR TITLE
fix react-native-google-signin ios error

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -390,7 +390,8 @@
     "android": true,
     "ios": true,
     "maintainersUsernames": ["vonovak"],
-    "notes": ""
+    "notes": "",
+    "patchFile": "patches/react-native-google-signin.patch"
   },
   "react-native-pdf": {
     "description": "A <Pdf /> component for react-native",

--- a/patches/react-native-google-signin.patch
+++ b/patches/react-native-google-signin.patch
@@ -1,0 +1,13 @@
+diff --git a/ios/Podfile b/ios/Podfile
+index b4aa3be..e93f3bc 100644
+--- a/ios/Podfile
++++ b/ios/Podfile
+@@ -17,6 +17,8 @@
+ target 'RNApp' do
+   config = use_native_modules!
+ 
++  pod 'AppCheckCore', '11.2.0'
++
+   use_react_native!(
+     :path => config[:reactNativePath],
+     # An absolute path to your application root.


### PR DESCRIPTION
# Why

fix nightly build error for react-native-google-signin

# How

workaround per https://github.com/react-native-google-signin/google-signin/issues/1517 and add the patch

# Test Plan

build passed
