### PR TITLE
ci: bump Xcode from 26.3 to 26.6 for iOS library builds

### DIFF
--- a/.github/actions/test-library-on-nightly/action.yml
+++ b/.github/actions/test-library-on-nightly/action.yml
@@ -60,7 +60,7 @@ runs:
       if: ${{ inputs.platform == 'ios' }}
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: 26.3.0
+        xcode-version: 26.6.0
     - name: Build iOS with retry
       if: ${{ inputs.platform == 'ios' }}
       uses: nick-fields/retry@v3


### PR DESCRIPTION
## Summary

Bumps iOS nightly builds from Xcode 26.3.0 → 26.6.0.

Unblocks `[ios] react-native-enriched-markdown`, which fails on 26.3 with `redefinition of module 'RaTeXFFI'` ([run](https://github.com/react-native-community/nightly-tests/actions/runs/29633686007/job/88052074654)).

The library-side fix is already shipped in [software-mansion/react-native-enriched-markdown#546](https://github.com/software-mansion/react-native-enriched-markdown/pull/546) (`SWIFT_ENABLE_EXPLICIT_MODULES=NO`), but Xcode 26.3 still ignores that opt-out; 26.6 respects it.

## Test plan

- [ ] Confirm runners expose Xcode 26.6
- [ ] Verify `[ios] react-native-enriched-markdown` is green on the next Check Nightlies run