### PR TITLE
update workflow actions to latests release, fully support Node 24

### DIFF
--- a/.github/actions/test-library-on-nightly/action.yml
+++ b/.github/actions/test-library-on-nightly/action.yml
@@ -24,7 +24,7 @@ runs:
         cd /tmp
         npx @react-native-community/cli init RNApp --skip-install --version nightly
     
-    
+
     - name: Apply patch if specified
       if: ${{ inputs.patch-file != '' }}
       shell: bash
@@ -38,9 +38,9 @@ runs:
           echo "⚠️  Warning: Patch file not found: ${{ inputs.patch-file }}"
           exit 1
         fi
-    
+
     - name: Add library with retry
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         timeout_minutes: 10
         max_attempts: ${{ inputs.retry-count }}
@@ -63,7 +63,7 @@ runs:
         xcode-version: 26.3.0
     - name: Build iOS with retry
       if: ${{ inputs.platform == 'ios' }}
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         timeout_minutes: 30
         max_attempts: ${{ inputs.retry-count }}
@@ -86,13 +86,13 @@ runs:
     # Android
     - name: Setup Java for Android
       if: ${{ inputs.platform == 'android' }}
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v5
       with:
         java-version: '17'
         distribution: 'zulu'
     - name: Build Android with retry
       if: ${{ inputs.platform == 'android' }}
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         timeout_minutes: 30
         max_attempts: ${{ inputs.retry-count }}

--- a/.github/workflows/check-nightly.yml
+++ b/.github/workflows/check-nightly.yml
@@ -24,7 +24,7 @@ jobs:
     if: github.repository == 'react-native-community/nightly-tests'
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Check nightly
         run: |
           TODAY=$(date "+%Y%m%d")

--- a/.github/workflows/check-website.yml
+++ b/.github/workflows/check-website.yml
@@ -14,10 +14,10 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: ⚙️ Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: 'yarn'

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -17,10 +17,10 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: ⚙️ Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: 'yarn'

--- a/.github/workflows/pr-check-new-entries.yml
+++ b/.github/workflows/pr-check-new-entries.yml
@@ -14,7 +14,7 @@ jobs:
       library-data: ${{ steps.read-libraries.outputs.library-data }}
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Diff and extract only changed libraries from JSON
         id: read-libraries
         run: |
@@ -49,9 +49,9 @@ jobs:
         platform: [ios, android]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: yarn

--- a/.github/workflows/test-js.yml
+++ b/.github/workflows/test-js.yml
@@ -12,9 +12,9 @@ jobs:
     if: github.repository == 'react-native-community/nightly-tests'
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: 'yarn'

--- a/.github/workflows/test-libraries-on-nightlies.yml
+++ b/.github/workflows/test-libraries-on-nightlies.yml
@@ -46,9 +46,9 @@ jobs:
         platform: [ios, android]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: yarn
@@ -68,7 +68,7 @@ jobs:
           echo "lib_folder=$LIB_FOLDER" >> $GITHUB_OUTPUT
       - name: Upload Artifact
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.save-outcome.outputs.lib_folder }}-${{ matrix.platform }}-outcome
           path: /tmp/${{ steps.save-outcome.outputs.lib_folder }}-${{ matrix.platform }}-outcome
@@ -80,12 +80,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Restore outcomes
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           pattern: '*-outcome'
           path: /tmp
       - name: Collect failures
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           FIREBASE_APP_EMAIL: ${{ secrets.firebase_app_email }}
           FIREBASE_APP_PASS: ${{ secrets.firebase_app_pass }}


### PR DESCRIPTION
# Why

GHA runner output warning for actions not fully supporting Node 24:

<img width="3088" height="613" alt="Screenshot 2026-07-19 202924" src="https://github.com/user-attachments/assets/91418da5-ca6d-4dfb-a348-b05fdb5571a4" />

# How

Update workflow actions to latests releases to fully support Node 24.