### PR TITLE
Enhance iOS retry cleanup in action.yml

### DIFF
--- a/.github/actions/test-library-on-nightly/action.yml
+++ b/.github/actions/test-library-on-nightly/action.yml
@@ -80,8 +80,10 @@ runs:
         on_retry_command: |
           echo "Cleaning up for iOS retry..."
           cd /tmp/RNApp/ios
+          bundle exec pod deintegrate
           rm -rf Pods Podfile.lock build
           rm -rf ~/Library/Developer/Xcode/DerivedData/* || true
+          bundle exec pod repo update
 
     # Android
     - name: Setup Java for Android


### PR DESCRIPTION
Add pod deintegrate command for iOS retry cleanup and fetch the updated pod repo for newly published pods