### PR TITLE
fix(react-native-firebase): use dynamic frameworks for iOS SPM

### DIFF
--- a/patches/react-native-firebase.patch
+++ b/patches/react-native-firebase.patch
@@ -2,12 +2,14 @@ diff --git a/ios/Podfile b/ios/Podfile
 index b4aa3be..cb46b59 100644
 --- a/ios/Podfile
 +++ b/ios/Podfile
-@@ -17,6 +17,8 @@ end
+@@ -17,6 +17,10 @@ end
  target 'RNApp' do
    config = use_native_modules!
  
-+  use_frameworks! :linkage => :static
-+  $RNFirebaseAsStaticFramework = true
++  # @react-native-firebase/app v26+ uses SPM by default and requires dynamic
++  # frameworks. Static linkage needs `$RNFirebaseDisableSPM = true` first.
++  # See https://rnfirebase.io/ios-spm
++  use_frameworks! :linkage => :dynamic
    use_react_native!(
      :path => config[:reactNativePath],
      # An absolute path to your application root.


### PR DESCRIPTION
## Summary
- `@react-native-firebase/app` v26+ resolves Firebase iOS deps via SPM by default, which requires `use_frameworks! :linkage => :dynamic`.
- The previous Podfile patch used static frameworks + `$RNFirebaseAsStaticFramework`, which now fails at `pod install` with `SPM + static linkage is not supported`.
- Update only `patches/react-native-firebase.patch` so the nightly smoke-tests the supported SPM path (with a short Podfile comment for the rationale). See https://rnfirebase.io/ios-spm

## Test plan
- [ ] Confirm iOS `@react-native-firebase/app` nightly job gets past `pod install` and builds
- [ ] Android job still green (unchanged)

Refs: https://react-native-community.github.io/nightly-tests/?q=fire · Invertase Linear [CPRN-288](https://linear.app/invertase/issue/CPRN-288/coordinate-with-rnmeta-photos-link-failure-build-config-spm-release)